### PR TITLE
Added version number and optimized PHP requirement in composer.json

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2021-05-18 Franz Holzinger <franz@ttproducts.de>
+ * bugfix issue #3: wrong PHP version constraint in composer.json
+
 2021-02-13 Franz Holzinger <franz@ttproducts.de>
  * support for TYPO3 10.4 and PHP 7.4
  * support the parameter object \JambageCom\Div2007\Api\StaticInfoTablesApi as well as \SJBR\StaticInfoTables\PiBaseApi 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "version": "0.5.0",
     "require": {
-        "php": ">=5.5.0,<=7.4.99",
+        "php": "^5.5 || ^7.2",
         "typo3/cms-core": ">=6.2.0,<=10.4.99",
         "typo3-ter/static-info-tables": "^6.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,9 @@
         "homepage": "https://ttproducts.de"
         }
     ],
+    "version": "0.5.0",
     "require": {
-        "php": "^5.5,^7.2",
+        "php": ">=5.5.0,<=7.4.99",
         "typo3/cms-core": ">=6.2.0,<=10.4.99",
         "typo3-ter/static-info-tables": "^6.5"
     },


### PR DESCRIPTION
The last changes to this repo made it PHP 7.4 compatible (https://github.com/franzholz/static_info_tables_taxes/commit/ceb57b9e577c36610c99c94f62543fef29df1dea). 
But due to its composer requirements it is not usable in an environment where the PHP version ist set to 7.4 via composer requirements.