### PR TITLE
Add support for composer-based installations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,11 @@
         "typo3/cms-core": "^10.4 || ^11.5",
         "sjbr/static-info-tables": "^6.7 || ^11.5"
     },
+    "autoload": {
+        "psr-4": {
+            "JambageCom\\StaticInfoTablesTaxes\\": "Classes"
+        }
+    },
     "replace": {
         "typo3-ter/static-info-tables-taxes": "self.version"
     },


### PR DESCRIPTION
This commit adds support for PSR-4 autoloading, which is needed for composer-based TYPO3 instances.

Without this commit, every attempt to use the included API class following official guidelines results in the API class being absent from the composer autoloader definitions and produces this error:
![Screenshot 2022-08-09 at 20 15 38](https://user-images.githubusercontent.com/12566993/183733144-c88c5591-7c4a-40de-958d-031395ddff02.jpg)

